### PR TITLE
fix: allow for nested subcondition path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mongoose-find-by-reference",
   "author": "CheezOne",
   "homepage": "https://github.com/cheezone/mongoose-find-by-reference",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Make Mongoose support finding in reference fields.",
   "main": "dist/main.js",
   "module": "dist/main.mjs",

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,7 @@ export function MongooseFindByReference(schema: Schema) {
 
     type Dict = { [key: string]: any };
     function flatten(dd: Dict, separator: string = '.', prefix: string = ''): Dict {
-      // transofrms nested subcondition to dot notation
+      // transform nested object to dot notation
       `
         { person: { name: "John" } } to { "person.name": "John" }
       `

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ export function MongooseFindByReference(schema: Schema) {
     throw new Error(i18n("schemaTypeError"));
 
   // 对 Schema 挂上钩子
-  schema.pre(["find", "findOne"], async function (next) {
+  schema.pre(["find", "findOne", "distinct"], async function (next) {
     /** 当前的 Model 们 */
     const models = this.model.db.models;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,12 +79,13 @@ export function MongooseFindByReference(schema: Schema) {
         } else {
           const currentModel = getModel(tSchema.path(previousPath.join(".")));
           if (currentModel) {
-            const result = [
-              previousPath.join("."),
-              ...transPath2RefPath([path, ...paths], currentModel.schema),
-            ];
-            return result;
-          } else return [path];
+            const recurseResult = transPath2RefPath([path, ...paths], currentModel.schema)
+            if (!paths.length) {
+              return [ previousPath.join("."), ...recurseResult ];
+            } else {
+              previousPath.push(...recurseResult);
+            }
+          } else return [...previousPath, path];
         }
       }
       return previousPath;
@@ -97,6 +98,28 @@ export function MongooseFindByReference(schema: Schema) {
         },
         $or:[]
     }`;
+
+    type Dict = { [key: string]: any };
+    function flatten(dd: Dict, separator: string = '.', prefix: string = ''): Dict {
+      // transofrms nested subcondition to dot notation
+      `
+        { person: { name: "John" } } to { "person.name": "John" }
+      `
+      let result: Dict = {};
+
+      for (let [k, v] of Object.entries(dd)) {
+          let key = prefix ? `${prefix}${separator}${k}` : k;
+
+          if (v.constructor === Object && !Object.keys(v).some( checkKey => checkKey.startsWith('$'))) {
+              let flatObject = flatten(v as Dict, separator, key);
+              result = { ...result, ...flatObject };
+          } else {
+              result[key] = v;
+          }
+      }
+
+      return result;
+    }
 
     async function lookup(
       prevPaths: string[],
@@ -155,7 +178,7 @@ export function MongooseFindByReference(schema: Schema) {
               const subCoditions = await lookup([], value, currentModel.schema);
               if (subCoditions) {
                 const ids = (
-                  await currentModel.find({ [paths]: subCoditions }, "_id")
+                  await currentModel.find(flatten({[paths]: subCoditions}), "_id")
                 ).map((v) => v._id);
 
                 return { $in: ids };


### PR DESCRIPTION
```javascript
{ person: { name: { first:  "John" } } 
```

flattens to 

```javascript
{ "person.name.first": "John" }
```
tested works for all datatypes and stops flattening at objects with $ keys. 
